### PR TITLE
renaming to frontend_deployment to suit future plans for backend

### DIFF
--- a/ansible/roles/xml-app-config/files/frontend_deployment.yml
+++ b/ansible/roles/xml-app-config/files/frontend_deployment.yml
@@ -74,6 +74,17 @@
           - "/tmp/{{ application_name }}-{{ version }}"
           - "/tmp/{{ application_name }}-{{ version }}.zip"
 
+      - name: Ensure apache config files are all owned and permissions are set correctly
+        ansible.builtin.file:
+          path: "{{ item }}"
+          owner: xml
+          group: chlservices
+          mode: '0644'
+        loop:
+          - /etc/httpd/conf/httpd.conf
+          - /etc/httpd/conf/startup.pl
+          - /etc/httpd/conf.d/perl.conf
+
       - name: Make sure Apache is started
         service:
           name: "httpd"


### PR DESCRIPTION
renaming to frontend_deployment to suit future plans for backend_depoyment inclusion, adding file ownership to the deployment