### PR TITLE
Renaming bucket variable to s3_bucket_releases as 2 buckets are used

### DIFF
--- a/ansible/roles/xml-app-config/files/frontend_deployment.yml
+++ b/ansible/roles/xml-app-config/files/frontend_deployment.yml
@@ -13,7 +13,7 @@
     tasks:
       - name: Download the versioned release artifact from S3
         aws_s3:
-          bucket: "{{ s3_bucket }}"
+          bucket: "{{ s3_bucket_releases }}"
           object: "chl-perl/{{ application_name }}/{{ application_name }}-{{ version }}.zip"
           dest: "/tmp/{{ application_name }}-{{ version }}.zip"
           mode: get


### PR DESCRIPTION
Renaming bucket variable to s3_bucket_releases as 2 buckets are used so being specific