### PR TITLE
Updating heritage_frontend collection version to use latest frontend base role for bep envvars

### DIFF
--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -1,7 +1,7 @@
 ---
 collections:
   - name: https://github.com/companieshouse/ansible-collections.git#ch_collections/heritage_services
-    version: 0.1.22
+    version: 0.1.29
     type: git
     
   - name: ansible.posix


### PR DESCRIPTION
Updating heritage_frontend collection version to use latest frontend base role for bep envvars