### PR TITLE
Rsyslog naming does not match syslog service definition but is used w…

### DIFF
--- a/ansible/host_vars/xml-frontend.yaml
+++ b/ansible/host_vars/xml-frontend.yaml
@@ -68,7 +68,7 @@ nrpe_command:
   check_httpd:
     script: check_service.sh
     option: $ARG1$
-  check_rsyslogd:
+  check_syslogd:
     script: check_service.sh
     option: $ARG1$
   check_users:


### PR DESCRIPTION
…ithin that definition in Nagios